### PR TITLE
Replace grid with usercontrol WebPageViewer

### DIFF
--- a/src/NAVPad Handling/WaldoNAVPad.Pag82100.al
+++ b/src/NAVPad Handling/WaldoNAVPad.Pag82100.al
@@ -1,17 +1,34 @@
 page 82100 "WaldoNAVPad"
 {
-    Caption = 'WaldoNAVPad';
+    Caption = 'WaldoNAVPad - Simplified';
     PageType = Card;
 
     layout
     {
         area(content)
         {
+            usercontrol(MyUserControl; "Microsoft.Dynamics.Nav.Client.WebPageViewer")
+            {
+                ApplicationArea = All;
+                trigger ControlAddInReady(callbackUrl: Text)
+                begin
+                    IsReady := true;
+                    FillAddIn();
+                end;
+
+                trigger Callback(data: Text)
+                begin
+                    FullText := data;
+                end;
+            }
+
+            //Cheap Fix: 
+            //Without this, the page's caption will not be displayed. It serves no other purpose.
             grid(Control1100084005)
             {
-                field(FullText; FullText)
+                field(CaptionDummy; '')
                 {
-                    MultiLine = true;
+                    Visible = false;
                     ShowCaption = false;
                     ApplicationArea = All;
                 }
@@ -22,6 +39,7 @@ page 82100 "WaldoNAVPad"
 
     var
         FullText: Text;
+        IsReady: Boolean;
 
     procedure SetText(Value: Text);
     begin
@@ -31,6 +49,11 @@ page 82100 "WaldoNAVPad"
     procedure GetText(): Text;
     begin
         exit(FullText);
+    end;
+
+    local procedure FillAddIn()
+    begin
+        CurrPage.MyUserControl.SetContent(StrSubstNo('<textarea Id="TextArea" maxlength="%2" style="width:100%;height:100%;resize: none; font-family:Segoe UI Segoe WP, Segoe, device-segoe, Tahoma, Helvetica, Arial, sans-serif; font-size: 12pt;" OnChange="window.parent.WebPageViewerHelper.TriggerCallback(document.getElementById(''TextArea'').value)">%1</textarea>', FullText, 4096));
     end;
 }
 


### PR DESCRIPTION
The grid field only displays three lines. The WebPageViewer allows the editor to resize itself to fit the entire page.